### PR TITLE
Fix reflection harvest accounting

### DIFF
--- a/src/atlas_main/memory_layers.py
+++ b/src/atlas_main/memory_layers.py
@@ -310,7 +310,7 @@ class ReflectionMemory:
         if not self.skills_path.exists():
             self.skills_path.write_text(json.dumps({"lessons": []}, indent=2))
 
-    def add(self, text: str, *, confidence: Optional[float] = None) -> None:
+    def add(self, text: str, *, confidence: Optional[float] = None) -> bool:
         try:
             data = json.loads(self.skills_path.read_text())
             lessons = data.get("lessons", [])
@@ -318,12 +318,12 @@ class ReflectionMemory:
             lessons = []
         normalized = (text or "").strip()
         if not normalized:
-            return
+            return False
         key = normalized.lower()
         for item in lessons:
             existing = str(item.get("text", "")).strip().lower()
             if existing == key:
-                return
+                return False
         lesson: dict[str, Any] = {"ts": time.time(), "text": normalized}
         if confidence is not None:
             try:
@@ -332,6 +332,7 @@ class ReflectionMemory:
                 pass
         lessons.append(lesson)
         self.skills_path.write_text(json.dumps({"lessons": lessons}, indent=2))
+        return True
 
     def recent(self, n: int = 5) -> List[dict]:
         try:
@@ -647,11 +648,14 @@ class LayeredMemoryManager:
             self._stats["harvest"]["accepted_facts"] += added_facts
         added_reflections = 0
         if lesson_items:
-            before = len(lesson_items)
             for lesson in lesson_items:
-                self.reflections.add(lesson["text"], confidence=lesson.get("confidence"))
-            added_reflections = before
-            self._stats["harvest"]["accepted_reflections"] += added_reflections
+                inserted = self.reflections.add(
+                    lesson["text"], confidence=lesson.get("confidence")
+                )
+                if inserted:
+                    added_reflections += 1
+            if added_reflections:
+                self._stats["harvest"]["accepted_reflections"] += added_reflections
 
         if added_facts or added_reflections:
             self._debug(

--- a/tests/test_cli_memory.py
+++ b/tests/test_cli_memory.py
@@ -137,3 +137,30 @@ def test_harvest_confidence_filtering(tmp_path, monkeypatch):
     assert stats["harvest"]["accepted_facts"] == 1
     assert stats["harvest"]["accepted_reflections"] == 1
     assert stats["harvest"]["rejected_low_confidence"] >= 2
+
+
+def test_harvest_reflection_deduplication(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATLAS_MEMORY_DIR", str(tmp_path))
+    config = LayeredMemoryConfig(base_dir=tmp_path)
+    manager = LayeredMemoryManager(embed_fn=lambda _text: None, config=config)
+
+    existing_lesson = "Remember to greet warmly."
+    manager.reflections.add(existing_lesson)
+
+    client = _FakeMemoryClient(
+        {
+            "reflections": [
+                {"text": existing_lesson, "confidence": 0.9},
+                {"text": "Offer scheduling reminders when appropriate.", "confidence": 0.8},
+            ]
+        }
+    )
+
+    manager.process_turn("Hello", "Hi there!", client=client)
+
+    lessons = manager.reflections.all()
+    assert len(lessons) == 2
+    assert any("scheduling reminders" in lesson["text"].lower() for lesson in lessons)
+
+    stats = manager.get_stats()
+    assert stats["harvest"]["accepted_reflections"] == 1


### PR DESCRIPTION
## Summary
- update reflection memory writes to report when new lessons are persisted
- adjust long-term harvest stats to only count newly stored reflections
- add a regression test ensuring duplicate reflections are not double-counted

## Testing
- PYTHONPATH=src pytest tests/test_cli_memory.py

------
https://chatgpt.com/codex/tasks/task_e_68df322681ac832b82d899d4c8d2022c